### PR TITLE
Add magic link verification

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,49 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Wizard from "./components/Wizard";
 
+function useAuthToken() {
+  const [token, setToken] = useState<string | null>(
+    localStorage.getItem("jwt")
+  );
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const t = url.searchParams.get("token");
+    if (t) {
+      fetch("http://localhost:5001/api/auth/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: t })
+      })
+        .then(async (r) => {
+          if (!r.ok) throw new Error("Invalid token");
+          const data = await r.json();
+          localStorage.setItem("jwt", data.jwt);
+          setToken(data.jwt);
+          url.searchParams.delete("token");
+          window.history.replaceState({}, "", url.pathname);
+        })
+        .catch(() => {
+          url.searchParams.delete("token");
+          window.history.replaceState({}, "", url.pathname);
+        });
+    }
+  }, []);
+
+  return token;
+}
+
 export default function App() {
+  const token = useAuthToken();
   return (
     <div className="page-container">
-      <Wizard />
+      {token ? (
+        <Wizard />
+      ) : (
+        <div style={{ textAlign: "center", marginTop: 40 }}>
+          Please check your email for the login link.
+        </div>
+      )}
     </div>
   );
 }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import transporter from '../services/email';
+import { storeMagicToken, verifyMagicLink } from '../services/authService';
 import crypto from 'crypto';
 
 const router = Router();
@@ -10,6 +11,7 @@ router.post('/magic-link', async (req, res) => {
     return res.status(400).json({ error: 'Email is required' });
   }
   const token = crypto.randomBytes(20).toString('hex');
+  storeMagicToken(email, token);
   const clientUrl = process.env.CLIENT_URL || 'http://localhost:3000';
   const link = `${clientUrl}/auth?token=${token}`;
 
@@ -25,6 +27,19 @@ router.post('/magic-link', async (req, res) => {
   } catch (error) {
     console.error('Error sending magic link email', error);
     res.status(500).json({ error: 'Failed to send email' });
+  }
+});
+
+router.post('/verify', (req, res) => {
+  const { token } = req.body;
+  if (!token) {
+    return res.status(400).json({ error: 'Token is required' });
+  }
+  try {
+    const jwt = verifyMagicLink(token);
+    res.json({ jwt });
+  } catch (err) {
+    res.status(400).json({ error: 'Invalid or expired token' });
   }
 });
 

--- a/server/services/authService.ts
+++ b/server/services/authService.ts
@@ -1,0 +1,27 @@
+import crypto from 'crypto';
+
+const tokens = new Map<string, string>();
+
+export function storeMagicToken(email: string, token: string): void {
+  tokens.set(token, email);
+}
+
+function signJwt(email: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: email })).toString('base64url');
+  const secret = process.env.JWT_SECRET || 'demo-secret';
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+export function verifyMagicLink(token: string): string {
+  const email = tokens.get(token);
+  if (!email) {
+    throw new Error('Invalid or expired token');
+  }
+  tokens.delete(token);
+  return signJwt(email);
+}

--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { storeMagicToken, verifyMagicLink } from '../server/services/authService';
+
+describe('verifyMagicLink', () => {
+  it('returns a JWT for a valid token', () => {
+    storeMagicToken('test@example.com', 'tok');
+    const jwt = verifyMagicLink('tok');
+    expect(typeof jwt).toBe('string');
+    expect(jwt.split('.').length).toBe(3);
+  });
+
+  it('throws for invalid token', () => {
+    expect(() => verifyMagicLink('bad')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add authService with magic link verification and JWT signing
- extend auth routes with `/verify`
- store magic tokens when sending magic link
- gate wizard behind JWT in the client
- add unit tests for verifyMagicLink

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm test` *(fails: vitest not found)*