### PR TITLE
Fix env variable name for server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # .env.example - environment variables for local development
 
 # Server settings
-SERVER_PORT=5000
+PORT=5000
 DATABASE_URL="file:./data/warren.db"
 CLAUDE_API_KEY=your_claude_api_key_here
 


### PR DESCRIPTION
## Summary
- rename `SERVER_PORT` to `PORT` in `.env.example`

## Testing
- `npm run lint -- --fix` *(fails: Parsing error)*
- `npm test` *(fails: vitest not found)*