### PR TITLE
feat: centralize API URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Copy `.env.example` to `server/.env` before running the development server:
 cp .env.example server/.env
 ```
 
+Create a `client/.env` file and set the API URL used by the React app:
+
+```
+echo "VITE_API_URL=http://localhost:5001" > client/.env
+```
+
 ### Scripts
 - `npm run dev`  
   Start server (Express on port 5001) and client (Vite on port 3000).
@@ -37,6 +43,7 @@ cp .env.example server/.env
 - `PORT`  - server port (default: 5001)
 - `DATABASE_URL`  - Prisma SQLite URL (default: file:../data/warren.db)
 - `CLIENT_URL`  - client base URL for magic-link (default: http://localhost:3000)
+- `VITE_API_URL` - API base URL for the React app (default: http://localhost:5001)
 
 ### Project Structure
 ```

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import Wizard from "./components/Wizard";
+import { API_URL } from "./config";
 
 function useAuthToken() {
   const [token, setToken] = useState<string | null>(
@@ -10,7 +11,7 @@ function useAuthToken() {
     const url = new URL(window.location.href);
     const t = url.searchParams.get("token");
     if (t) {
-      fetch("http://localhost:5001/api/auth/verify", {
+      fetch(`${API_URL}/api/auth/verify`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token: t })

--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import WizardStepObjective from "./WizardStepObjective";
 import WizardStepQuestions from "./WizardStepQuestions";
+import { API_URL } from "../config";
 
 // Step enums for readability.
 enum Step {
@@ -39,7 +40,7 @@ export default function Wizard() {
     setQuestions([]);
     // Call API
     try {
-      const res = await fetch("http://localhost:5001/api/claude", {
+      const res = await fetch(`${API_URL}/api/claude`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ objective: obj })
@@ -50,7 +51,7 @@ export default function Wizard() {
       }
       const data = await res.json();
 
-      const save = await fetch("http://localhost:5001/api/survey", {
+      const save = await fetch(`${API_URL}/api/survey`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ objective: obj, questions: data.questions })

--- a/client/src/components/WizardStepQuestions.tsx
+++ b/client/src/components/WizardStepQuestions.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Question } from "./Wizard";
+import { API_URL } from "../config";
 
 interface Props {
   surveyId: string;
@@ -130,7 +131,7 @@ export default function WizardStepQuestions({
                       onQuestionChange(q.id, txt);
                       if (timers.current[q.id]) clearTimeout(timers.current[q.id]);
                       timers.current[q.id] = setTimeout(() => {
-                        fetch(`http://localhost:5001/api/survey/${surveyId}/question/${q.id}`, {
+                        fetch(`${API_URL}/api/survey/${surveyId}/question/${q.id}`, {
                           method: "PATCH",
                           headers: { "Content-Type": "application/json" },
                           body: JSON.stringify({ text: txt })

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001';


### PR DESCRIPTION
## Summary
- add `client/src/config.ts` for VITE_API_URL
- use `API_URL` in client components
- document setting `VITE_API_URL` in README

## Testing
- `npm run lint --fix` *(fails: Parsing error)*
- `npm test` *(fails: vitest not found)*