### PR TITLE
Integrate real Claude API for question generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ PORT=5000
 DATABASE_URL="file:./data/warren.db"
 
 CLAUDE_API_KEY=your_claude_api_key_here
+CLAUDE_MODEL=claude-3-haiku-20240307
+CLAUDE_TIMEOUT_MS=10000
 
 # MailHog settings
 MAILHOG_SMTP_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ echo "VITE_API_URL=http://localhost:5001" > client/.env
 - `DATABASE_URL`  - Prisma SQLite URL (default: file:../data/warren.db)
 - `CLIENT_URL`  - client base URL for magic-link (default: http://localhost:3000)
 - `VITE_API_URL` - API base URL for the React app (default: http://localhost:5001)
+- `CLAUDE_API_KEY` - Anthropic Claude API key for question generation (optional)
+- `CLAUDE_MODEL` - Claude model name (default: claude-3-haiku-20240307)
+- `CLAUDE_TIMEOUT_MS` - timeout for Claude API calls (default: 10000)
 
 ### Project Structure
 ```


### PR DESCRIPTION
## Summary
- connect `generateQuestions` to Anthropic Claude API
- include Survey Methodology Framework in the generation prompt
- add CLAUDE_MODEL and CLAUDE_TIMEOUT_MS env vars
- document Claude env vars in README

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm test` *(fails: vitest not found)*
