### PR TITLE
Add centralized theme and loading animation

### DIFF
--- a/client/src/animations.css
+++ b/client/src/animations.css
@@ -1,0 +1,4 @@
+@keyframes lds-bounce {
+  0%, 80%, 100% { transform: scale(0.85); }
+  40% { transform: scale(1); }
+}

--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import WizardStepObjective from "./WizardStepObjective";
 import WizardStepQuestions from "./WizardStepQuestions";
 import { API_URL } from "../config";
+import { colors } from "../theme";
 
 // Step enums for readability.
 enum Step {
@@ -26,6 +27,7 @@ export default function Wizard() {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [regenerating, setRegenerating] = useState<string | null>(null);
 
   const goToStep = (target: Step) => setStep(target);
   const handleBack = () => setStep((prev) => (prev === Step.Questions ? Step.Objective : prev));
@@ -44,6 +46,7 @@ export default function Wizard() {
     qid: string,
     feedback: string
   ) => {
+    setRegenerating(qid);
     try {
       const res = await fetch(`${API_URL}/api/claude/regenerate`, {
         method: 'POST',
@@ -61,6 +64,8 @@ export default function Wizard() {
       );
     } catch (err) {
       console.error(err);
+    } finally {
+      setRegenerating(null);
     }
   };
 
@@ -111,7 +116,7 @@ export default function Wizard() {
   // Pretty horizontal step indicator styled close to reference.
   function Stepper() {
     // Color definitions (brand blue and stepper grays)
-    const brandBlue = "#276EF1"; // example Warren-blue
+    const brandBlue = colors.primaryDarkBlue;
     const gray = "#D2D6DB";
     return (
       <div
@@ -141,7 +146,7 @@ export default function Wizard() {
               alignItems: "center",
               justifyContent: "center",
               fontSize: 20,
-              boxShadow: step === Step.Objective ? "0 2px 8px #276EF122" : undefined,
+              boxShadow: step === Step.Objective ? "0 2px 8px #2A3F5422" : undefined,
               marginRight: 10,
               transition: "background 0.2s",
             }}
@@ -150,7 +155,7 @@ export default function Wizard() {
           </div>
           <span
             style={{
-              color: step === Step.Objective ? brandBlue : "#333",
+              color: step === Step.Objective ? brandBlue : colors.primaryText,
               fontWeight: step === Step.Objective ? 600 : 400,
               fontSize: 16,
               letterSpacing: "0.01em",
@@ -188,7 +193,7 @@ export default function Wizard() {
               alignItems: "center",
               justifyContent: "center",
               fontSize: 20,
-              boxShadow: step === Step.Questions ? "0 2px 8px #276EF122" : undefined,
+              boxShadow: step === Step.Questions ? "0 2px 8px #2A3F5422" : undefined,
               marginRight: 10,
               marginLeft: 10,
               transition: "background 0.2s",
@@ -198,7 +203,7 @@ export default function Wizard() {
           </div>
           <span
             style={{
-              color: step === Step.Questions ? brandBlue : "#333",
+              color: step === Step.Questions ? brandBlue : colors.primaryText,
               fontWeight: step === Step.Questions ? 600 : 400,
               fontSize: 16,
               letterSpacing: "0.01em",
@@ -222,7 +227,7 @@ export default function Wizard() {
         boxShadow: "0 6px 32px rgba(37,74,138,0.08)",
         padding: "2.2rem 2.5rem 2.2rem 2.5rem",
         borderRadius: 24,
-        background: "#f9fbff",
+        background: colors.offWhite,
         border: "1.5px solid #e7e7ef",
       }}
     >
@@ -231,7 +236,7 @@ export default function Wizard() {
         marginBottom: 18,
         fontSize: 32,
         fontWeight: 700,
-        color: "#276EF1",
+        color: colors.primaryDarkBlue,
         textAlign: "center",
         letterSpacing: "0.015em"
       }}>
@@ -251,6 +256,7 @@ export default function Wizard() {
           objective={objective}
           surveyId={surveyId as string}
           questions={questions}
+          regeneratingId={regenerating}
           onQuestionChange={handleQuestionChange}
           onStatusChange={handleStatusChange}
           onRegenerate={handleRegenerate}

--- a/client/src/components/WizardStepObjective.tsx
+++ b/client/src/components/WizardStepObjective.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { colors } from "../theme";
+import "../animations.css";
 
 interface Props {
   initialObjective?: string;
@@ -20,7 +22,7 @@ export default function WizardStepObjective({ initialObjective = "", loading, er
   };
   return (
     <form onSubmit={handleFormSubmit} style={{ maxWidth: 500, margin: "0 auto" }}>
-      <label htmlFor="objective" style={{ fontWeight: 600, fontSize: 18, marginBottom: 5, display: "block", color: "#1b2945" }}>
+      <label htmlFor="objective" style={{ fontWeight: 600, fontSize: 18, marginBottom: 5, display: "block", color: colors.primaryDarkBlue }}>
         Survey Objective
       </label>
       <textarea
@@ -54,7 +56,7 @@ export default function WizardStepObjective({ initialObjective = "", loading, er
         disabled={loading}
         style={{
           minWidth: 160,
-          background: "#276EF1",
+          background: colors.primaryDarkBlue,
           color: "white",
           border: "none",
           fontWeight: 600,
@@ -109,15 +111,6 @@ export default function WizardStepObjective({ initialObjective = "", loading, er
           "Generate Questions"
         )}
       </button>
-      {/* Loading spinner keyframes */}
-      <style>
-        {`
-          @keyframes lds-bounce {
-            0%, 80%, 100% { transform: scale(0.85);}
-            40% { transform: scale(1);}
-          }
-        `}
-      </style>
     </form>
   );
 }

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,0 +1,16 @@
+export const colors = {
+  primaryDarkBlue: '#2A3F54',
+  secondaryGreen: '#6EAD7C',
+  offWhite: '#F8F7F4',
+  sidebarGray: '#E9ECEF',
+  headerBlueGray: '#DDE2E7',
+  loginCardBg: '#F3F7F2',
+  primaryText: '#333333',
+  secondaryText: '#6C757D',
+  border: '#CED4DA',
+  loginCardBorder: '#D2E0D1',
+  badgeExemplary: '#6EAD7C',
+  badgeFoundational: '#D9534F',
+  badgeAdvanced: '#5BC0DE',
+  badgeProficient: '#F0AD4E'
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,17 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
 export default [
   {
     files: ['**/*.{js,ts,tsx}'],
     ignores: ['dist', 'node_modules'],
     languageOptions: {
       ecmaVersion: 'latest',
-      sourceType: 'module'
+      sourceType: 'module',
+      parser: require.resolve('@typescript-eslint/parser')
+    },
+    plugins: {
+      '@typescript-eslint': require('@typescript-eslint/eslint-plugin')
     },
     rules: {}
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "concurrently": "^8.2.0",
     "eslint": "^8.52.0",
     "prisma": "^6.8.2",
-    "vitest": "^0.34.6"
+    "vitest": "^0.34.6",
+    "@typescript-eslint/parser": "^6.7.3",
+    "@typescript-eslint/eslint-plugin": "^6.7.3"
   }
 }


### PR DESCRIPTION
## Summary
- create shared color palette in `theme.ts`
- move loading keyframes to `animations.css`
- update wizard components to use new theme colors and shared animation
- import animation stylesheet and clean up inline styles

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*