### PR TITLE
Add question text to regenerate API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,21 @@ GitHub Actions runs ESLint and Vitest on PRs to `main`.
 2. When the app loads, enter your email and submit the form.
 3. MailHog (http://localhost:8025) will receive an email containing a magic link.
 4. Clicking the link verifies the token and stores a JWT in `localStorage`, unlocking the survey wizard.
+
+## API
+
+### Regenerate a Question
+
+`POST /api/claude/regenerate`
+
+Request body:
+
+```json
+{ "objective": "string", "question": "string", "feedback": "string" }
+```
+
+The endpoint revises the provided `question` using the teacher's `feedback` and returns:
+
+```json
+{ "question": { "text": "...", "rubric": ["..."] } }
+```

--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -42,17 +42,18 @@ export default function Wizard() {
     );
   };
 
-  const handleRegenerate = async (
-    qid: string,
-    feedback: string
-  ) => {
-    setRegenerating(qid);
-    try {
-      const res = await fetch(`${API_URL}/api/claude/regenerate`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ objective, feedback })
-      });
+const handleRegenerate = async (
+  qid: string,
+  feedback: string
+) => {
+  setRegenerating(qid);
+  try {
+    const current = questions.find(q => q.id === qid)?.text || '';
+    const res = await fetch(`${API_URL}/api/claude/regenerate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ objective, question: current, feedback })
+    });
       if (!res.ok) {
         throw new Error('Failed to regenerate');
       }

--- a/server/routes/claude.ts
+++ b/server/routes/claude.ts
@@ -24,20 +24,23 @@ router.post('/', async (req, res) => {
 
 /**
  * POST /api/claude/regenerate
- * Body: { objective: string, feedback: string }
+ * Body: { objective: string, question: string, feedback: string }
  * Response: { question: { text: string; rubric: string[] } }
  */
 router.post('/regenerate', async (req, res) => {
-  const { objective, feedback } = req.body;
+  const { objective, question, feedback } = req.body;
   if (!objective || typeof objective !== 'string') {
     return res.status(400).json({ error: 'Objective is required' });
+  }
+  if (!question || typeof question !== 'string') {
+    return res.status(400).json({ error: 'Question is required' });
   }
   if (!feedback || typeof feedback !== 'string') {
     return res.status(400).json({ error: 'Feedback is required' });
   }
   try {
-    const question = await regenerateQuestion(objective, feedback);
-    res.json({ question });
+    const regenerated = await regenerateQuestion(objective, question, feedback);
+    res.json({ question: regenerated });
   } catch (error) {
     console.error('Error regenerating question:', error);
     res.status(500).json({ error: 'Failed to regenerate question' });

--- a/tests/claudeService.test.ts
+++ b/tests/claudeService.test.ts
@@ -15,7 +15,11 @@ describe('generateQuestions', () => {
 
 describe('regenerateQuestion', () => {
   it('returns a single question', async () => {
-    const q = await regenerateQuestion('Engagement', 'make it shorter');
+    const q = await regenerateQuestion(
+      'Engagement',
+      'Why is engagement important?',
+      'make it shorter'
+    );
     expect(q.text.length).toBeGreaterThan(0);
     expect(Array.isArray(q.rubric)).toBe(true);
     expect(q.rubric.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- include question text when regenerating with Claude
- validate question field in the regenerate route
- send question text from the front-end regenerate handler
- update regenerateQuestion unit test
- document new regenerate endpoint

## Testing
- `npm run lint --silent` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test --silent` *(fails: vitest not found)*