### PR TITLE
Fix blank screen when regenerating questions

### DIFF
--- a/client/src/components/WizardStepQuestions.tsx
+++ b/client/src/components/WizardStepQuestions.tsx
@@ -183,7 +183,11 @@ export default function WizardStepQuestions({
                           type="button"
                           disabled={isRegen}
                           onClick={async () => {
-                            await onRegenerate(q.id, feedback);
+                            try {
+                              await onRegenerate(q.id, feedback);
+                            } catch (err) {
+                              console.error(err);
+                            }
                             setFeedbacks({ ...feedbacks, [q.id]: "" });
                           }}
                           style={{


### PR DESCRIPTION
## Summary
- handle errors when regenerating questions so unhandled rejections don't crash the React app
- wrap regenerate button click in a try/catch

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest: not found)*