### PR TITLE
Fix rubric rendering

### DIFF
--- a/client/src/components/WizardStepQuestions.tsx
+++ b/client/src/components/WizardStepQuestions.tsx
@@ -157,7 +157,7 @@ export default function WizardStepQuestions({
                     />
                   </div>
                   <div style={{ marginBottom: 8 }}>
-                    {q.rubric.map((tag, rIdx) => (
+                    {(Array.isArray(q.rubric) ? q.rubric : []).map((tag, rIdx) => (
                       <RubricBadge tag={tag} key={rIdx} />
                     ))}
                   </div>

--- a/tests/WizardStepQuestions.test.tsx
+++ b/tests/WizardStepQuestions.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import WizardStepQuestions from '../client/src/components/WizardStepQuestions';
+
+// Simple noop handlers for required callbacks
+const noop = () => {};
+
+describe('WizardStepQuestions', () => {
+  it('renders without crashing when a question lacks rubric', () => {
+    const question: any = { id: 'q1', text: 'What is 2+2?' };
+    expect(() =>
+      renderToString(
+        <WizardStepQuestions
+          surveyId="1"
+          objective="math"
+          questions={[question]}
+          onQuestionChange={noop}
+          onStatusChange={noop}
+          onRegenerate={noop}
+          onBack={noop}
+        />
+      )
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing rubric tags in WizardStepQuestions
- test WizardStepQuestions with missing rubric

## Testing
- `npm run lint -- --fix` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*