### PR TITLE
Fix rubric display regression

### DIFF
--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -11,12 +11,14 @@ enum Step {
 }
 
 // Define the structure for individual rubric items if they are objects
-export interface RubricItem {
-  Category: string; // Assuming 'Category' holds the displayable tag string
-  Assessment?: string; // Optional, if present in your data
-  Rationale?: string;  // Optional, if present in your data
-  // Add any other properties Claude might return for a rubric item
+export interface RubricObject {
+  Category: string; // Display tag string from Claude
+  Assessment?: string;
+  Rationale?: string;
 }
+
+// Rubric items can come back as simple strings or the full object above
+export type RubricItem = RubricObject | string;
 
 export interface GeneratedQuestion {
   text: string;

--- a/client/src/components/WizardStepQuestions.tsx
+++ b/client/src/components/WizardStepQuestions.tsx
@@ -27,7 +27,7 @@ const rubricColors: Record<string, { bg: string; color: string }> = {
 };
 
 function RubricBadge({ item }: { item: RubricItem }) {
-  const displayTag = item.Category;
+  const displayTag = typeof item === 'string' ? item : item.Category;
   const color = rubricColors[displayTag] || rubricColors.default;
   return (
     <span


### PR DESCRIPTION
## Summary
- support rubric items returned as plain strings

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest: not found)*