### PR TITLE
Fix question regeneration display

### DIFF
--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -69,11 +69,12 @@ const handleRegenerate = async (
       const err = await res.json();
       throw new Error(err.error || 'Failed to regenerate');
     }
-    const { question: newQuestion } = await res.json(); // unwrap the returned question
+    const { question: newQuestion } = await res.json();
+    const qData = Array.isArray(newQuestion) ? newQuestion[0] : newQuestion;
     setQuestions((prev) =>
       prev.map((q) =>
         q.id === qid
-          ? { ...q, text: newQuestion.text, rubric: newQuestion.rubric }
+          ? { ...q, text: qData.text, rubric: qData.rubric }
           : q
       )
     );

--- a/server/services/claudeService.ts
+++ b/server/services/claudeService.ts
@@ -137,7 +137,8 @@ export async function regenerateQuestion(
     const text = data.content?.[0]?.text?.trim();
     if (!text) throw new Error('Claude API returned empty content');
 
-    return JSON.parse(text) as GeneratedQuestion;
+    const parsed = JSON.parse(text);
+    return (Array.isArray(parsed) ? parsed[0] : parsed) as GeneratedQuestion;
   } finally {
     clearTimeout(id);
   }


### PR DESCRIPTION
## Summary
- handle Claude returning arrays when regenerating questions on both backend and frontend

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*