### PR TITLE
Implement bulk student answer seeding

### DIFF
--- a/server/db/llmResponseSeed.ts
+++ b/server/db/llmResponseSeed.ts
@@ -1,0 +1,53 @@
+import { PrismaClient } from '@prisma/client';
+import { generateBulkStudentAnswers } from '../services/claudeService';
+
+const prisma = new PrismaClient();
+
+async function main(): Promise<void> {
+  const survey = await prisma.survey.findFirst({
+    orderBy: { createdAt: 'desc' },
+    include: { questions: true }
+  });
+
+  if (!survey || !survey.questions || survey.questions.length === 0) {
+    console.error('No survey with questions found.');
+    return;
+  }
+
+  const numberOfStudents = 30;
+  const allQuestionAnswers: Record<string, string[]> = {};
+
+  for (const question of survey.questions) {
+    try {
+      const answers = await generateBulkStudentAnswers(question.text, numberOfStudents);
+      allQuestionAnswers[question.id] = answers;
+    } catch (err) {
+      console.error(`Failed to generate answers for question ${question.id}:`, err);
+      allQuestionAnswers[question.id] = new Array(numberOfStudents).fill('Default answer due to LLM error.');
+    }
+  }
+
+  const responsesToCreate: { questionId: string; answer: string }[] = [];
+  for (let i = 0; i < numberOfStudents; i++) {
+    for (const question of survey.questions) {
+      const answer = allQuestionAnswers[question.id]?.[i] ?? 'Placeholder answer';
+      responsesToCreate.push({ questionId: question.id, answer });
+    }
+  }
+
+  if (responsesToCreate.length > 0) {
+    await prisma.response.createMany({ data: responsesToCreate });
+    console.log(`Created ${responsesToCreate.length} responses.`);
+  } else {
+    console.log('No responses created.');
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
 
     "dev": "nodemon --watch . --ext ts --exec \"ts-node index.ts\"",
     "db:seed": "ts-node ./db/seed.ts",
-    "demo:seed": "ts-node ./db/demoSeed.ts"
+    "demo:seed": "ts-node ./db/demoSeed.ts",
+    "db:seed:llm-responses": "ts-node ./db/llmResponseSeed.ts"
 
   },
   "dependencies": {

--- a/server/services/claudeService.ts
+++ b/server/services/claudeService.ts
@@ -143,3 +143,55 @@ export async function regenerateQuestion(
     clearTimeout(id);
   }
 }
+export async function generateBulkStudentAnswers(questionText: string, count = 30): Promise<string[]> {
+  const prompt = `You are a student answering a survey question. Provide ${count} distinct and realistic answers in a JSON array. Question: ${questionText}\n\nReturn strictly a JSON array of ${count} strings. Example: [\"Answer 1\", \"Answer 2\"]`;
+  const timeoutMs = Number(process.env.CLAUDE_TIMEOUT_MS || 10000);
+  const apiKey = process.env.CLAUDE_API_KEY;
+
+  if (!apiKey) {
+    return Array.from({ length: count }, (_, i) => `Sample answer ${i + 1} to: ${questionText}`);
+  }
+
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: process.env.CLAUDE_MODEL || 'claude-3-haiku-20240307',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: prompt }]
+      })
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`Claude API error ${res.status}: ${errText}`);
+    }
+
+    const data = await res.json();
+    const text = data.content?.[0]?.text?.trim();
+    if (!text) throw new Error('Claude API returned empty content');
+
+    let answers: unknown = JSON.parse(text);
+    if (!Array.isArray(answers)) {
+      throw new Error('Claude response is not an array');
+    }
+    answers = answers.map((a) => String(a));
+    if (answers.length < count) {
+      answers = answers.concat(Array.from({ length: count - answers.length }, () => 'Default generated answer'));
+    } else if (answers.length > count) {
+      answers = answers.slice(0, count);
+    }
+    return answers as string[];
+  } finally {
+    clearTimeout(id);
+  }
+}

--- a/tests/claudeService.test.ts
+++ b/tests/claudeService.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { generateQuestions, regenerateQuestion } from '../server/services/claudeService';
+import {
+  generateQuestions,
+  regenerateQuestion,
+  generateBulkStudentAnswers
+} from '../server/services/claudeService';
 
 describe('generateQuestions', () => {
   it('returns at least 5 questions with rubric tags', async () => {
@@ -23,5 +27,18 @@ describe('regenerateQuestion', () => {
     expect(q.text.length).toBeGreaterThan(0);
     expect(Array.isArray(q.rubric)).toBe(true);
     expect(q.rubric.length).toBeGreaterThan(0);
+  });
+});
+
+describe('generateBulkStudentAnswers', () => {
+  it('returns the requested number of answers', async () => {
+    const count = 5;
+    const answers = await generateBulkStudentAnswers('What did you learn?', count);
+    expect(Array.isArray(answers)).toBe(true);
+    expect(answers.length).toBe(count);
+    for (const a of answers) {
+      expect(typeof a).toBe('string');
+      expect(a.length).toBeGreaterThan(0);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- generate multiple student answers via Claude service
- seed 30 answers per question in newest survey
- expose new seeding script through npm
- cover new Claude helper with tests

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*