### PR TITLE
Add survey seeding and analysis endpoints

### DIFF
--- a/client/src/components/StudentPlaceholder.tsx
+++ b/client/src/components/StudentPlaceholder.tsx
@@ -85,6 +85,17 @@ export default function StudentPlaceholder() {
         </button>
         <div className="survey-card">
           <h1 style={{ marginTop: 0, color: colors.primaryText }}>Thanks for submitting!</h1>
+          <button
+            className="survey-button-primary"
+            type="button"
+            onClick={async () => {
+              await fetch(`${API_URL}/api/survey/${survey.id}/seed`, { method: 'POST' });
+              await fetch(`${API_URL}/api/survey/${survey.id}/analyze`, { method: 'POST' });
+              alert('Survey seeded and analyzed');
+            }}
+          >
+            Seed the Survey
+          </button>
         </div>
       </div>
     );

--- a/server/routes/survey.ts
+++ b/server/routes/survey.ts
@@ -5,6 +5,10 @@ import {
   deploySurvey,
   getActiveSurvey
 } from '../services/surveyService';
+import {
+  seedResponsesForSurvey
+} from '../services/responseService';
+import { analyzeSurveyResponses } from '../services/analysisService';
 
 const router = Router();
 
@@ -55,6 +59,28 @@ router.get('/active', async (_req, res) => {
   } catch (error) {
     console.error('Error fetching active survey:', error);
     res.status(500).json({ error: 'Failed to fetch survey' });
+  }
+});
+
+router.post('/:id/seed', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const created = await seedResponsesForSurvey(id);
+    res.json({ created });
+  } catch (error) {
+    console.error('Error seeding survey:', error);
+    res.status(500).json({ error: 'Failed to seed survey' });
+  }
+});
+
+router.post('/:id/analyze', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const analysis = await analyzeSurveyResponses(id);
+    res.json({ analysis });
+  } catch (error) {
+    console.error('Error analyzing survey:', error);
+    res.status(500).json({ error: 'Failed to analyze survey' });
   }
 });
 

--- a/server/services/analysisService.ts
+++ b/server/services/analysisService.ts
@@ -1,0 +1,30 @@
+import { prisma } from '../db/client';
+import { getSurveyAnalysisFromClaude } from './claudeService';
+
+export async function formatSurveyForAnalysis(surveyId: string): Promise<string> {
+  const survey = await prisma.survey.findUnique({
+    where: { id: surveyId },
+    include: { questions: { include: { responses: true } } }
+  });
+  if (!survey) throw new Error(`Survey ${surveyId} not found`);
+
+  let content = `Survey Objective: ${survey.objective}\n\n`;
+  survey.questions.forEach((q, idx) => {
+    content += `Question ${idx + 1}: ${q.text}\n`;
+    content += `Student Responses to Question ${idx + 1}:\n[\n`;
+    q.responses.forEach((r, i) => {
+      const answer = r.answer.replace(/"/g, '\\"');
+      content += `  "${answer}"${i < q.responses.length - 1 ? ',' : ''}\n`;
+    });
+    content += `]\n\n`;
+  });
+  return content;
+}
+
+export async function analyzeSurveyResponses(surveyId: string): Promise<string> {
+  const surveyContent = await formatSurveyForAnalysis(surveyId);
+  const instructions =
+    'You are an expert qualitative data analyst assisting educators. Analyze the following anonymous survey responses. For each question provide themes, overall sentiment, representative quotes, any outliers, and 2-3 key takeaways. After all questions, summarise the entire survey. Return Markdown formatted text.';
+  const prompt = `${instructions}\n\n${surveyContent}`;
+  return getSurveyAnalysisFromClaude(prompt);
+}

--- a/server/services/responseService.ts
+++ b/server/services/responseService.ts
@@ -9,3 +9,27 @@ export async function saveResponses(responses: ResponseInput[]): Promise<void> {
   if (responses.length === 0) return;
   await prisma.response.createMany({ data: responses });
 }
+
+import { generateBulkStudentAnswers } from './claudeService';
+
+export async function seedResponsesForSurvey(surveyId: string, count = 30): Promise<number> {
+  const survey = await prisma.survey.findUnique({
+    where: { id: surveyId },
+    include: { questions: true }
+  });
+  if (!survey || !survey.questions.length) {
+    throw new Error('Survey not found or has no questions');
+  }
+
+  const responses: ResponseInput[] = [];
+  for (const q of survey.questions) {
+    const answers = await generateBulkStudentAnswers(q.text, count);
+    for (let i = 0; i < count; i++) {
+      responses.push({ questionId: q.id, answer: answers[i] || '' });
+    }
+  }
+  if (responses.length) {
+    await prisma.response.createMany({ data: responses });
+  }
+  return responses.length;
+}

--- a/tests/responseService.test.ts
+++ b/tests/responseService.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { seedResponsesForSurvey } from '../server/services/responseService';
+import { createWithQuestions } from '../server/services/surveyService';
+import { prisma } from '../server/db/client';
+
+beforeAll(async () => {
+  await prisma.response.deleteMany();
+  await prisma.question.deleteMany();
+  await prisma.survey.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('seedResponsesForSurvey', () => {
+  it('creates responses for each question', async () => {
+    const survey = await createWithQuestions('Obj', [{ text: 'Q1' }, { text: 'Q2' }]);
+    const created = await seedResponsesForSurvey(survey.id, 5);
+    expect(created).toBe(10);
+    const count = await prisma.response.count({ where: { question: { surveyId: survey.id } } });
+    expect(count).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- allow students to seed the survey after submission
- generate demo responses and send them to Claude for analysis
- expose `/api/survey/:id/seed` and `/api/survey/:id/analyze`
- support analysis via new service helpers
- test response seeding logic

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest: not found)*