### PR TITLE
Fix Vite server host

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000
+    port: 3000,
+    host: '0.0.0.0'
   }
 });


### PR DESCRIPTION
## Summary
- allow the Vite dev server to bind to all network interfaces

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*