### PR TITLE
Fix question regen persistence

### DIFF
--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -78,6 +78,14 @@ const handleRegenerate = async (
           : q
       )
     );
+    if (surveyId) {
+      // Persist the regenerated text to the survey just like manual edits
+      await fetch(`${API_URL}/api/survey/${surveyId}/question/${qid}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: qData.text })
+      });
+    }
   } catch (err: any) {
     console.error(err);
     setError(err.message || 'Failed to regenerate');


### PR DESCRIPTION
## Summary
- persist regenerated question text via PATCH to survey question endpoint

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9131a458832489aae45276121eef