### PR TITLE
Add sentiment analysis and chart view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ AI Summary & Teacher Results Screen (Sprint 4)
 analysisService.summarizeResponses using Claude/OpenAI; cache result.
 
 Results page shows charts + AI narrative.
+Sentiment analysis stored per question via sentimentService; GET /api/survey/:id/sentiment powers new ResultsCharts UI toggle.
 
 Exports
 

--- a/README.md
+++ b/README.md
@@ -87,3 +87,15 @@ The endpoint revises the provided `question` using the teacher's `feedback` and 
 ```json
 { "question": { "text": "...", "rubric": ["..."] } }
 ```
+
+### Sentiment Analysis
+
+`GET /api/survey/:id/sentiment`
+
+Returns sentiment scores for each question:
+
+```json
+{ "questions": [ { "id": "...", "text": "...", "sentimentScore": 0.5 } ] }
+```
+
+In the results screen you can toggle between the Markdown analysis and a chart view powered by this endpoint.

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
-    "remark-gfm": "^3.0.1"
+    "remark-gfm": "^3.0.1",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/client/src/components/ResultsCharts.tsx
+++ b/client/src/components/ResultsCharts.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { API_URL } from '../config';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface QuestionSentiment {
+  id: string;
+  text: string;
+  sentimentScore: number | null;
+}
+
+export default function ResultsCharts({ surveyId }: { surveyId: string }) {
+  const [data, setData] = useState<QuestionSentiment[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/survey/${surveyId}/sentiment`)
+      .then((res) => res.json())
+      .then((d) => setData(d.questions || []))
+      .catch(() => setData([]));
+  }, [surveyId]);
+
+  if (!data.length) return <div>No sentiment data.</div>;
+
+  const chartData = {
+    labels: data.map((q) => q.text),
+    datasets: [
+      {
+        label: 'Sentiment Score',
+        data: data.map((q) => q.sentimentScore || 0),
+        backgroundColor: 'rgba(75,192,192,0.6)'
+      }
+    ]
+  };
+
+  return <Bar data={chartData} />;
+}

--- a/client/src/components/ResultsView.tsx
+++ b/client/src/components/ResultsView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { API_URL } from '../config';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import ResultsCharts from './ResultsCharts';
 
 interface SurveyAnalysis {
   analysis: string;
@@ -19,6 +20,7 @@ export default function ResultsView({ surveyId: propSurveyId, onGoBackToList }: 
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [currentSurveyId, setCurrentSurveyId] = useState<string | null>(propSurveyId);
+  const [mode, setMode] = useState<'markdown' | 'charts'>('markdown');
 
   useEffect(() => {
     async function fetchActiveSurvey() {
@@ -95,10 +97,20 @@ export default function ResultsView({ surveyId: propSurveyId, onGoBackToList }: 
         </button>
       )}
       <h1 style={{ marginTop: 0 }}>Survey Analysis</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <button onClick={() => setMode('markdown')} disabled={mode === 'markdown'}>
+          Markdown
+        </button>
+        <button onClick={() => setMode('charts')} disabled={mode === 'charts'} style={{ marginLeft: '0.5rem' }}>
+          Charts
+        </button>
+      </div>
       <div style={{ color: '#333', lineHeight: 1.6 }}>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-          {analysis}
-        </ReactMarkdown>
+        {mode === 'markdown' ? (
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{analysis}</ReactMarkdown>
+        ) : (
+          currentSurveyId && <ResultsCharts surveyId={currentSurveyId} />
+        )}
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prisma": "^6.8.2",
     "vitest": "^0.34.6",
     "@typescript-eslint/parser": "^6.7.3",
-    "@typescript-eslint/eslint-plugin": "^6.7.3"
+    "@typescript-eslint/eslint-plugin": "^6.7.3",
+    "supertest": "^6.3.3"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
     "dotenv": "^16.3.1",
     "nodemailer": "^6.9.3",
     "@prisma/client": "^6.8.2",
-    "yaml": "^2.3.1"
+    "yaml": "^2.3.1",
+    "sentiment": "^5.1.1"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/server/prisma/migrations/20250604012900_add_sentiment/migration.sql
+++ b/server/prisma/migrations/20250604012900_add_sentiment/migration.sql
@@ -1,0 +1,3 @@
+-- Manual migration for sentiment fields
+ALTER TABLE Question ADD COLUMN sentimentScore REAL;
+ALTER TABLE Question ADD COLUMN sentimentSummary TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,6 +22,8 @@ model Question {
   surveyId   String
   text       String
   createdAt  DateTime   @default(now())
+  sentimentScore Float?
+  sentimentSummary String?
   survey     Survey     @relation(fields: [surveyId], references: [id])
   responses  Response[]
 }

--- a/server/routes/survey.ts
+++ b/server/routes/survey.ts
@@ -5,7 +5,8 @@ import {
   deploySurvey,
   getActiveSurvey,
   getSurveyAnalysis,
-  getAnalyzedSurveys
+  getAnalyzedSurveys,
+  getSurveySentiment
 } from '../services/surveyService';
 import {
   seedResponsesForSurvey
@@ -109,6 +110,17 @@ router.get('/:id/analysisResult', async (req, res) => {
   } catch (error) {
     console.error('Error fetching survey analysis:', error);
     res.status(500).json({ error: 'Failed to fetch survey analysis' });
+  }
+});
+
+router.get('/:id/sentiment', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const questions = await getSurveySentiment(id);
+    res.json({ questions });
+  } catch (error) {
+    console.error('Error fetching survey sentiment:', error);
+    res.status(500).json({ error: 'Failed to fetch survey sentiment' });
   }
 });
 

--- a/server/services/analysisService.ts
+++ b/server/services/analysisService.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../db/client';
 import { getSurveyAnalysisFromClaude } from './claudeService';
 import { storeSurveyAnalysis } from './surveyService';
+import { calculateSentiment } from './sentimentService';
 
 export async function formatSurveyForAnalysis(surveyId: string): Promise<string> {
   const survey = await prisma.survey.findUnique({
@@ -28,6 +29,13 @@ export async function analyzeSurveyResponses(surveyId: string): Promise<string> 
     'You are an expert qualitative data analyst assisting educators. Analyze the following anonymous survey responses. For each question provide themes, overall sentiment, representative quotes, any outliers, and 2-3 key takeaways. After all questions, summarise the entire survey. Return Markdown formatted text.';
   const prompt = `${instructions}\n\n${surveyContent}`;
   const analysisText = await getSurveyAnalysisFromClaude(prompt);
+  const survey = await prisma.survey.findUnique({ where: { id: surveyId }, include: { questions: true } });
+  if (survey) {
+    for (const q of survey.questions) {
+      const score = await calculateSentiment(q.id);
+      await prisma.question.update({ where: { id: q.id }, data: { sentimentScore: score } });
+    }
+  }
   await storeSurveyAnalysis(surveyId, analysisText);
   return analysisText;
 }

--- a/server/services/sentimentService.ts
+++ b/server/services/sentimentService.ts
@@ -1,0 +1,15 @@
+import { prisma } from '../db/client';
+import Sentiment from 'sentiment';
+
+const sentiment = new Sentiment();
+
+export async function calculateSentiment(questionId: string): Promise<number> {
+  const responses = await prisma.response.findMany({
+    where: { questionId },
+    select: { answer: true }
+  });
+  if (responses.length === 0) return 0;
+  const scores = responses.map((r) => sentiment.analyze(r.answer).score);
+  const avg = scores.reduce((sum, s) => sum + s, 0) / scores.length;
+  return avg;
+}

--- a/server/services/surveyService.ts
+++ b/server/services/surveyService.ts
@@ -91,6 +91,15 @@ export async function getSurveyAnalysis(surveyId: string): Promise<string | null
   });
   return survey?.analysisResultText || null;
 }
+
+export async function getSurveySentiment(
+  surveyId: string
+): Promise<Array<{ id: string; text: string; sentimentScore: number | null }>> {
+  return prisma.question.findMany({
+    where: { surveyId },
+    select: { id: true, text: true, sentimentScore: true }
+  });
+}
 /**
  * Fetch all surveys for which analysisResultText is not null (i.e., analysis has been stored).
  */

--- a/tests/sentimentService.test.ts
+++ b/tests/sentimentService.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { calculateSentiment } from '../server/services/sentimentService';
+import { createWithQuestions } from '../server/services/surveyService';
+import { prisma } from '../server/db/client';
+
+beforeAll(async () => {
+  await prisma.response.deleteMany();
+  await prisma.question.deleteMany();
+  await prisma.survey.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('calculateSentiment', () => {
+  it('computes average sentiment from responses', async () => {
+    const survey = await createWithQuestions('Obj', [{ text: 'Q1' }]);
+    await prisma.response.createMany({
+      data: [
+        { questionId: survey.questions[0].id, answer: 'I love it' },
+        { questionId: survey.questions[0].id, answer: 'bad experience' }
+      ]
+    });
+    const score = await calculateSentiment(survey.questions[0].id);
+    expect(typeof score).toBe('number');
+  });
+});

--- a/tests/surveySentimentRoute.test.ts
+++ b/tests/surveySentimentRoute.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { app } from '../server/index';
+import { prisma } from '../server/db/client';
+import { createWithQuestions } from '../server/services/surveyService';
+
+beforeAll(async () => {
+  await prisma.response.deleteMany();
+  await prisma.question.deleteMany();
+  await prisma.survey.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('GET /api/survey/:id/sentiment', () => {
+  it('returns sentiment scores for questions', async () => {
+    const survey = await createWithQuestions('Obj', [{ text: 'Q1' }]);
+    await prisma.response.create({
+      data: { questionId: survey.questions[0].id, answer: 'great' }
+    });
+    const res = await request(app).get(`/api/survey/${survey.id}/sentiment`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.questions)).toBe(true);
+    expect(res.body.questions[0]).toHaveProperty('sentimentScore');
+  });
+});


### PR DESCRIPTION
## Summary
- extend Prisma schema with sentiment columns
- add sentimentService and wire into analysisService
- expose GET `/api/survey/:id/sentiment`
- show ResultsCharts component and toggle on results page
- document new flow
- add tests for sentiment service and route

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa11e11c4832481895d473b890003