### PR TITLE
Fix server sentiment dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
     "nodemailer": "^6.9.3",
     "@prisma/client": "^6.8.2",
     "yaml": "^2.3.1",
-    "sentiment": "^5.1.1"
+    "sentiment": "^5.0.2"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",


### PR DESCRIPTION
## Summary
- pin server's `sentiment` dependency to `^5.0.2`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint -- --fix` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa65efa2c83249f4b37dfda11f479