### PR TITLE
Add branching survey prototype

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import Wizard from "./components/Wizard";
 import Sidebar from "./components/Sidebar";
 import DashboardView from "./components/DashboardView";
-import StudentPlaceholder from "./components/StudentPlaceholder";
+import BranchingSurveyPlayer from "./components/BranchingSurveyPlayer";
 import ResultsView from "./components/ResultsView";
 import DenHome from "./components/DenHome";
 
@@ -63,7 +63,7 @@ export default function App() {
   }
 
   if (role === "student") {
-    return <StudentPlaceholder />;
+    return <BranchingSurveyPlayer surveyId="active" />;
   }
 
   // Callback for DenHome to select a specific survey from the list

--- a/client/src/components/BranchingSurveyPlayer.tsx
+++ b/client/src/components/BranchingSurveyPlayer.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { API_URL } from '../config';
+
+interface NodeData {
+  id: string;
+  type: string;
+  content: { text: string; options?: string[] };
+}
+
+export default function BranchingSurveyPlayer({ surveyId }: { surveyId: string }) {
+  const [node, setNode] = useState<NodeData | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/survey/branching/${surveyId}/start`)
+      .then((r) => r.json())
+      .then((d) => setNode(d.node));
+  }, [surveyId]);
+
+  async function handleSubmit(answer: string) {
+    const res = await fetch(`${API_URL}/survey/branching/${surveyId}/next`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentNodeId: node?.id, answer })
+    });
+    const data = await res.json();
+    setNode(data.node);
+  }
+
+  if (!node) return <div>Loading...</div>;
+
+  if (node.type === 'message') {
+    return (
+      <div>
+        <p>{node.content.text}</p>
+        <button onClick={() => handleSubmit('')}>Continue</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p>{node.content.text}</p>
+      {node.content.options?.map((o) => (
+        <button key={o} onClick={() => handleSubmit(o)}>
+          {o}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/FlowEditor.tsx
+++ b/client/src/components/FlowEditor.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import ReactFlow, { Node, Edge } from 'react-flow-renderer';
+import { API_URL } from '../config';
+
+interface Graph {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export default function FlowEditor() {
+  const [graph, setGraph] = useState<Graph>({ nodes: [], edges: [] });
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`${API_URL}/survey/branching`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ objective: 'Demo branching survey' })
+      });
+      const data = await res.json();
+      const nodes = data.survey.nodes.map((n: any) => ({ id: n.id, data: n.content, position: { x: 0, y: 0 } }));
+      const edges = data.survey.edges.map((e: any) => ({ id: e.id, source: e.sourceNodeId, target: e.targetNodeId }));
+      setGraph({ nodes, edges });
+    }
+    load();
+  }, []);
+
+  return (
+    <div style={{ height: 400 }}>
+      <ReactFlow nodes={graph.nodes} edges={graph.edges} />
+    </div>
+  );
+}

--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import WizardStepObjective from "./WizardStepObjective";
-import WizardStepQuestions from "./WizardStepQuestions";
+import FlowEditor from "./FlowEditor";
 import { API_URL } from "../config";
 import { colors } from "../theme";
 
@@ -276,20 +276,7 @@ const handleRegenerate = async (
           onSubmit={handleObjectiveSubmit}
         />
       )}
-      {step === Step.Questions && (
-        <WizardStepQuestions
-          objective={objective}
-          surveyId={surveyId as string}
-          questions={questions}
-          regeneratingId={regenerating}
-          onQuestionChange={handleQuestionChange}
-          onStatusChange={handleStatusChange}
-          onRegenerate={handleRegenerate}
-          loading={loading}
-          error={error}
-          onBack={handleBack}
-        />
-      )}
+      {step === Step.Questions && <FlowEditor />}
     </div>
   );
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -9,29 +9,41 @@ datasource db {
 }
 
 model Survey {
-  id        String     @id @default(cuid())
+  id        String   @id @default(cuid())
   objective String
-  questions Question[]
-  createdAt DateTime   @default(now())
+  createdAt DateTime @default(now())
   deployedAt DateTime?
   analysisResultText String?
+  nodes     Node[]
+  edges     Edge[]
 }
 
-model Question {
-  id         String     @id @default(cuid())
-  surveyId   String
-  text       String
-  createdAt  DateTime   @default(now())
-  sentimentScore Float?
-  sentimentSummary String?
-  survey     Survey     @relation(fields: [surveyId], references: [id])
-  responses  Response[]
+model Node {
+  id           String   @id @default(cuid())
+  surveyId     String
+  survey       Survey   @relation(fields: [surveyId], references: [id])
+  type         String
+  content      Json
+  outgoingEdges Edge[]  @relation("SourceNode")
+  incomingEdges Edge[]  @relation("TargetNode")
+  responses    Response[]
+}
+
+model Edge {
+  id           String  @id @default(cuid())
+  surveyId     String
+  survey       Survey  @relation(fields: [surveyId], references: [id])
+  sourceNodeId String
+  targetNodeId String
+  sourceNode   Node    @relation("SourceNode", fields: [sourceNodeId], references: [id])
+  targetNode   Node    @relation("TargetNode", fields: [targetNodeId], references: [id])
+  conditionValue String?
 }
 
 model Response {
-  id         String    @id @default(cuid())
-  questionId String
-  answer     String
-  createdAt  DateTime  @default(now())
-  question   Question  @relation(fields: [questionId], references: [id])
+  id        String   @id @default(cuid())
+  nodeId    String
+  node      Node     @relation(fields: [nodeId], references: [id])
+  answer    String
+  createdAt DateTime @default(now())
 }

--- a/server/routes/survey.ts
+++ b/server/routes/survey.ts
@@ -9,11 +9,67 @@ import {
   getSurveySentiment
 } from '../services/surveyService';
 import {
+  createBranchingSurvey,
+  updateBranchingSurvey,
+  getEntryNode,
+  getNextNode
+} from '../services/branchingSurveyService';
+import { generateBranchingSurvey } from '../services/claudeService';
+import {
   seedResponsesForSurvey
 } from '../services/responseService';
 import { analyzeSurveyResponses } from '../services/analysisService';
 
 const router = Router();
+
+router.post('/branching', async (req, res) => {
+  const { objective } = req.body;
+  if (!objective) {
+    return res.status(400).json({ error: 'Objective is required' });
+  }
+  try {
+    const graph = await generateBranchingSurvey(objective);
+    const survey = await createBranchingSurvey(objective, graph);
+    res.json({ survey });
+  } catch (error) {
+    console.error('Error creating branching survey:', error);
+    res.status(500).json({ error: 'Failed to create survey' });
+  }
+});
+
+router.put('/branching/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const survey = await updateBranchingSurvey(id, req.body);
+    res.json({ survey });
+  } catch (error) {
+    console.error('Error updating branching survey:', error);
+    res.status(500).json({ error: 'Failed to update survey' });
+  }
+});
+
+router.get('/branching/:id/start', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const node = await getEntryNode(id);
+    res.json({ node });
+  } catch (error) {
+    console.error('Error getting entry node:', error);
+    res.status(500).json({ error: 'Failed to fetch entry node' });
+  }
+});
+
+router.post('/branching/:id/next', async (req, res) => {
+  const { id } = req.params;
+  const { currentNodeId, answer } = req.body;
+  try {
+    const node = await getNextNode(id, currentNodeId, answer);
+    res.json({ node });
+  } catch (error) {
+    console.error('Error getting next node:', error);
+    res.status(500).json({ error: 'Failed to fetch next node' });
+  }
+});
 
 router.post('/', async (req, res) => {
   const { objective, questions } = req.body;

--- a/server/services/branchingSurveyService.ts
+++ b/server/services/branchingSurveyService.ts
@@ -1,0 +1,91 @@
+import { prisma } from '../prisma/client';
+import { BranchingSurvey } from './claudeService';
+
+export interface NodeInput {
+  id: string;
+  type: string;
+  content: any;
+}
+
+export interface EdgeInput {
+  source: string;
+  target: string;
+  conditionValue?: string;
+}
+
+export async function createBranchingSurvey(
+  objective: string,
+  graph: BranchingSurvey
+) {
+  return prisma.survey.create({
+    data: {
+      objective,
+      nodes: {
+        create: graph.nodes.map((n: NodeInput) => ({
+          id: n.id,
+          type: n.type,
+          content: n.content
+        }))
+      },
+      edges: {
+        create: graph.edges.map((e: EdgeInput) => ({
+          sourceNodeId: e.source,
+          targetNodeId: e.target,
+          conditionValue: e.conditionValue
+        }))
+      }
+    },
+    include: { nodes: true, edges: true }
+  });
+}
+
+export async function updateBranchingSurvey(
+  surveyId: string,
+  graph: BranchingSurvey
+) {
+  await prisma.node.deleteMany({ where: { surveyId } });
+  await prisma.edge.deleteMany({ where: { surveyId } });
+
+  await prisma.node.createMany({
+    data: graph.nodes.map((n: NodeInput) => ({
+      id: n.id,
+      surveyId,
+      type: n.type,
+      content: n.content
+    }))
+  });
+
+  await prisma.edge.createMany({
+    data: graph.edges.map((e: EdgeInput) => ({
+      surveyId,
+      sourceNodeId: e.source,
+      targetNodeId: e.target,
+      conditionValue: e.conditionValue
+    }))
+  });
+
+  return prisma.survey.findUnique({
+    where: { id: surveyId },
+    include: { nodes: true, edges: true }
+  });
+}
+
+export async function getEntryNode(surveyId: string) {
+  return prisma.node.findFirst({ where: { surveyId, id: 'entry' } });
+}
+
+export async function getNextNode(
+  surveyId: string,
+  currentNodeId: string,
+  answer: string
+) {
+  const edge = await prisma.edge.findFirst({
+    where: {
+      surveyId,
+      sourceNodeId: currentNodeId,
+      OR: [{ conditionValue: answer }, { conditionValue: null }]
+    }
+  });
+  if (!edge) return null;
+  return prisma.node.findUnique({ where: { id: edge.targetNodeId } });
+}

--- a/server/services/claudeService.ts
+++ b/server/services/claudeService.ts
@@ -241,3 +241,48 @@ export async function getSurveyAnalysisFromClaude(promptContent: string): Promis
     clearTimeout(id);
   }
 }
+
+export interface BranchingSurvey {
+  nodes: any[];
+  edges: any[];
+}
+
+export async function generateBranchingSurvey(objective: string): Promise<BranchingSurvey> {
+  const prompt = `You are a survey designer creating a branching survey for the objective: "${objective}".
+Return ONLY a valid JSON object with \"nodes\" and \"edges\" keys.
+- Nodes must have a unique \"id\", a \"type\" ('message' or 'question-multiple-choice'), and \"content\" ({ "text": "...", "options": [...] }). The first node id must be \"entry\".
+- Edges must have a \"source\" id, a \"target\" id, and an optional \"conditionValue\" string which matches an option from the source question.`;
+
+  const apiKey = process.env.CLAUDE_API_KEY;
+  const timeoutMs = Number(process.env.CLAUDE_TIMEOUT_MS || 10000);
+  if (!apiKey || process.env.NODE_ENV === 'test') {
+    return { nodes: [], edges: [] };
+  }
+
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: process.env.CLAUDE_MODEL || 'claude-3-haiku-20240307',
+        max_tokens: 2048,
+        messages: [{ role: 'user', content: prompt }]
+      })
+    });
+
+    const json = await res.json();
+    const text = json.content?.[0]?.text?.trim() || '';
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error('Claude response did not contain JSON');
+    return JSON.parse(match[0]);
+  } finally {
+    clearTimeout(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add Node/Edge models to Prisma schema
- implement generateBranchingSurvey in `claudeService`
- create new service for persisting branching survey graphs
- add branching survey endpoints
- add React Flow editor and branching survey player
- switch Student view to new player

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dad6f583c83248aaca945ea9ddedd