### PR TITLE
Fix schema relations for responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ Returns the next node in the sequence: `{ "node": { ... } }`.
 ### Student Responses
 
 `POST /api/responses`
-Request body: `{ "responses": [ { "questionId": "string", "answer": "string" }, ... ] }`
-Saves student responses: `{ "message": "Saved" }`.
+Request body should include an array of objects each containing a `questionId` and the student's `answer`:
+`{ "responses": [ { "questionId": "string", "answer": "string" }, ... ] }`
+The `questionId` corresponds to the question record returned when fetching a survey.
+Successful requests return `{ "message": "Saved" }`.
 
 ### Analysis & Sentiment
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -31,11 +31,13 @@ model Question {
 }
 
 model Response {
-  id         String    @id @default(cuid())
-  nodeId     String
+  id         String   @id @default(cuid())
+  questionId String
+  nodeId     String?
   answer     String
-  createdAt  DateTime  @default(now())
-  node       Node      @relation(fields: [nodeId], references: [id])
+  createdAt  DateTime @default(now())
+  question   Question @relation(fields: [questionId], references: [id])
+  node       Node?    @relation(fields: [nodeId], references: [id])
 }
 
 /// New models for branching surveys


### PR DESCRIPTION
## Summary
- restore questionId relation on `Response` model
- clarify response schema in README

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc409cf648324b925e2458eb65779