### PR TITLE
Support optional questionId for responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ Returns the next node in the sequence: `{ "node": { ... } }`.
 ### Student Responses
 
 `POST /api/responses`
-Request body should include an array of objects each containing a `questionId` and the student's `answer`:
-`{ "responses": [ { "questionId": "string", "answer": "string" }, ... ] }`
-The `questionId` corresponds to the question record returned when fetching a survey.
+Request body should include an array of objects with the student's `answer` and either a `questionId` or a `nodeId` for branching surveys:
+`{ "responses": [ { "questionId": "string", "answer": "string" }, { "nodeId": "string", "answer": "string" } ] }`
+The `questionId` corresponds to the question record returned when fetching a survey. Branching surveys send `nodeId` instead.
 Successful requests return `{ "message": "Saved" }`.
 
 ### Analysis & Sentiment

--- a/server/prisma/migrations/20250614201100_optional-question-id/migration.sql
+++ b/server/prisma/migrations/20250614201100_optional-question-id/migration.sql
@@ -1,0 +1,2 @@
+-- Manual migration for optional questionId
+-- TODO: make questionId nullable and adjust foreign key

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -32,11 +32,11 @@ model Question {
 
 model Response {
   id         String   @id @default(cuid())
-  questionId String
+  questionId String?
   nodeId     String?
   answer     String
   createdAt  DateTime @default(now())
-  question   Question @relation(fields: [questionId], references: [id])
+  question   Question? @relation(fields: [questionId], references: [id])
   node       Node?    @relation(fields: [nodeId], references: [id])
 }
 

--- a/server/services/responseService.ts
+++ b/server/services/responseService.ts
@@ -8,7 +8,13 @@ export interface ResponseInput {
 
 export async function saveResponses(responses: ResponseInput[]): Promise<void> {
   if (responses.length === 0) return;
-  await prisma.response.createMany({ data: responses });
+  await prisma.response.createMany({
+    data: responses.map((r) => ({
+      questionId: r.questionId ?? null,
+      nodeId: r.nodeId,
+      answer: r.answer
+    }))
+  });
 }
 
 import { generateBulkStudentAnswers } from './claudeService';


### PR DESCRIPTION
## Summary
- allow `questionId` to be nullable in Prisma schema
- record nullable `questionId` when saving responses
- document node-based responses in README
- add skeleton migration for nullable `questionId`

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npx prisma migrate dev --name optional-question-id` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find module '@typescript-eslint/parser')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd71332b883248d7a990d21565de5