### PR TITLE
Add branching survey seeding and analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "tunnel": "bash ./scripts/tunnel.sh",
     "demo:seed": "npm --prefix server run demo:seed",
     "db:seed": "npm --prefix server run db:seed",
+    "db:seed:branching": "ts-node server/db/branchingResponseSeed.ts",
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "test": "vitest"
   },

--- a/server/db/branchingResponseSeed.ts
+++ b/server/db/branchingResponseSeed.ts
@@ -1,0 +1,79 @@
+import { PrismaClient, Node } from '@prisma/client';
+import { getEntryNode, getNextNode } from '../services/branchingSurveyService';
+
+const prisma = new PrismaClient();
+
+async function simulateStudent(surveyId: string, entryNode: Node) {
+  let currentNode: Node | null = entryNode;
+  const responses: { nodeId: string; answer: string }[] = [];
+
+  while (currentNode) {
+    if (currentNode.type === 'question-multiple-choice') {
+      const options = (currentNode.content as any)?.options;
+      if (!options || options.length === 0) {
+        break; // Stop if a question has no options
+      }
+      const answer = options[Math.floor(Math.random() * options.length)];
+      responses.push({ nodeId: currentNode.id, answer });
+      currentNode = await getNextNode(surveyId, currentNode.id, answer);
+    } else {
+      currentNode = await getNextNode(surveyId, currentNode.id, '');
+    }
+  }
+
+  return responses;
+}
+
+async function main() {
+  console.log('Starting to seed branching survey responses...');
+
+  const survey = await prisma.survey.findFirst({
+    where: {
+      nodes: {
+        some: {}
+      }
+    },
+    orderBy: {
+      createdAt: 'desc'
+    }
+  });
+
+  if (!survey) {
+    console.error('No branching surveys found to seed. Please create one first.');
+    return;
+  }
+
+  console.log(`Seeding responses for survey: "${survey.objective}" (ID: ${survey.id})`);
+
+  const entryNode = await getEntryNode(survey.id);
+  if (!entryNode) {
+    console.error('Could not find an entry node for the survey.');
+    return;
+  }
+
+  const numberOfStudents = 25;
+  let allResponses: { nodeId: string; answer: string }[] = [];
+
+  for (let i = 0; i < numberOfStudents; i++) {
+    const studentResponses = await simulateStudent(survey.id, entryNode);
+    allResponses.push(...studentResponses);
+  }
+
+  if (allResponses.length > 0) {
+    await prisma.response.createMany({
+      data: allResponses
+    });
+    console.log(`Successfully seeded ${allResponses.length} responses for ${numberOfStudents} students.`);
+  } else {
+    console.log('No responses were generated to seed.');
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/routes/survey.ts
+++ b/server/routes/survey.ts
@@ -11,7 +11,11 @@ import {
 import {
   seedResponsesForSurvey
 } from '../services/responseService';
-import { analyzeSurveyResponses } from '../services/analysisService';
+import {
+  analyzeSurveyResponses,
+  analyzeBranchingSurvey
+} from '../services/analysisService';
+import { prisma } from '../prisma/client';
 
 const router = Router();
 
@@ -79,7 +83,24 @@ router.post('/:id/seed', async (req, res) => {
 router.post('/:id/analyze', async (req, res) => {
   const { id } = req.params;
   try {
-    const analysis = await analyzeSurveyResponses(id);
+    const survey = await prisma.survey.findUnique({
+      where: { id },
+      include: { _count: { select: { nodes: true } } }
+    });
+
+    if (!survey) {
+      return res.status(404).json({ error: 'Survey not found' });
+    }
+
+    let analysis: string;
+    if (survey._count.nodes > 0) {
+      console.log(`Analyzing branching survey ${id}...`);
+      analysis = await analyzeBranchingSurvey(id);
+    } else {
+      console.log(`Analyzing linear survey ${id}...`);
+      analysis = await analyzeSurveyResponses(id);
+    }
+
     res.json({ analysis });
   } catch (error) {
     console.error('Error analyzing survey:', error);

--- a/server/services/analysisService.ts
+++ b/server/services/analysisService.ts
@@ -39,3 +39,52 @@ export async function analyzeSurveyResponses(surveyId: string): Promise<string> 
   await storeSurveyAnalysis(surveyId, analysisText);
   return analysisText;
 }
+
+/**
+ * Formats a branching survey's questions and responses for AI analysis.
+ * It groups all responses by their corresponding question node.
+ */
+export async function formatBranchingSurveyForAnalysis(surveyId: string): Promise<string> {
+  const survey = await prisma.survey.findUnique({
+    where: { id: surveyId },
+    include: {
+      nodes: {
+        where: { type: 'question-multiple-choice' },
+        include: { responses: true }
+      }
+    }
+  });
+
+  if (!survey) throw new Error(`Survey ${surveyId} not found`);
+
+  let content = `Branching Survey Objective: ${survey.objective}\n\n`;
+
+  survey.nodes.forEach((node, idx) => {
+    if (node.responses.length > 0) {
+      content += `Question ${idx + 1}: ${(node.content as any).text}\n`;
+      content += `Student Responses to Question ${idx + 1}:\n[\n`;
+      node.responses.forEach((r, i) => {
+        const answer = r.answer.replace(/"/g, '\\"');
+        content += `  "${answer}"${i < node.responses.length - 1 ? ',' : ''}\n`;
+      });
+      content += `]\n\n`;
+    }
+  });
+
+  return content;
+}
+
+/**
+ * Triggers the AI analysis for a branching survey.
+ */
+export async function analyzeBranchingSurvey(surveyId: string): Promise<string> {
+  const surveyContent = await formatBranchingSurveyForAnalysis(surveyId);
+  const instructions =
+    'You are an expert qualitative data analyst. Analyze the following branching survey responses. For each question, provide themes, overall sentiment, representative quotes, and key takeaways. After all questions, summarize the entire survey. Return Markdown formatted text.';
+  const prompt = `${instructions}\n\n${surveyContent}`;
+  const analysisText = await getSurveyAnalysisFromClaude(prompt);
+
+  await storeSurveyAnalysis(surveyId, analysisText);
+
+  return analysisText;
+}


### PR DESCRIPTION
## Summary
- seed branching survey responses with `db:seed:branching`
- support analysis for branching surveys
- update analyse route to detect survey type

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b47e89508324b979f0245e084f03