### PR TITLE
Implement existing survey listing and chat enhancements

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,8 @@ import DashboardView from "./components/DashboardView";
 import StudentPlaceholder from "./components/StudentPlaceholder";
 import ResultsView from "./components/ResultsView";
 import DenHome from "./components/DenHome";
+import ExistingSurveysView from "./components/ExistingSurveysView";
+import ChatOverlay from "./components/ChatOverlay";
 
 import Login from "./Login";
 import "./index.css";
@@ -38,6 +40,7 @@ export default function App() {
   const { token, role } = useAuthInfo();
   const [page, setPage] = useState("dashboard");
   const [activeSurveyIdForResults, setActiveSurveyIdForResults] = useState<string | null>(null);
+  const [demoSurveyId, setDemoSurveyId] = useState<string | null>(null);
 
   const handleNavigate = (p: string, surveyId?: string) => {
     if (p === "results") {
@@ -71,6 +74,10 @@ export default function App() {
     setActiveSurveyIdForResults(surveyId);
   };
 
+  const handleSelectExistingSurvey = (id: string) => {
+    setDemoSurveyId(id);
+  };
+
   return (
     <div className="dashboard-layout">
       <Sidebar active={page} onNavigate={handleNavigate} onLogout={handleLogout} />
@@ -86,10 +93,18 @@ export default function App() {
           )
         ) : page === 'builder' ? (
           <Wizard />
+        ) : page === 'existing' ? (
+          <>
+            <ExistingSurveysView onSelectSurvey={handleSelectExistingSurvey} />
+            {demoSurveyId && (
+              <ChatOverlay surveyId={demoSurveyId} onClose={() => setDemoSurveyId(null)} />
+            )}
+          </>
         ) : (
           <DashboardView
             onStartSurvey={() => setPage('builder')}
             onViewResults={(surveyId?: string) => handleNavigate('results', surveyId)}
+            onGoToExisting={() => setPage('existing')}
           />
         )}
       </div>

--- a/client/src/components/BranchingGraphView.tsx
+++ b/client/src/components/BranchingGraphView.tsx
@@ -100,6 +100,7 @@ export default function BranchingGraphView({
   const [showRationaleModal, setShowRationaleModal] = useState(false);
   const [rationaleContent, setRationaleContent] = useState('');
   const [showChat, setShowChat] = useState(false);
+  const [surveyComplete, setSurveyComplete] = useState(false);
 
   const handleTextChange = (id: string, text: string) =>
     setNodes((nds) =>
@@ -248,6 +249,8 @@ export default function BranchingGraphView({
         console.warn('Dropping invalid edges before save');
       }
       await onSave(updatedNodes, validEdges);
+      const isComplete = nodes.every((node) => node.id === 'thank_you');
+      setSurveyComplete(isComplete);
     } finally {
       setSaving(false);
     }
@@ -287,6 +290,17 @@ export default function BranchingGraphView({
           style={{ marginTop: '1rem', marginLeft: '1rem' }}
         >
           Demo Survey
+        </button>
+        <button
+          className="login-button"
+          disabled={!surveyComplete}
+          style={{
+            marginTop: '1rem',
+            marginLeft: '1rem',
+            backgroundColor: surveyComplete ? 'green' : 'grey'
+          }}
+        >
+          Seed and Analyze Survey
         </button>
         </div>
       </div>

--- a/client/src/components/ChatOverlay.tsx
+++ b/client/src/components/ChatOverlay.tsx
@@ -37,12 +37,13 @@ export default function ChatOverlay({ surveyId, onClose }: ChatOverlayProps) {
     scrollRef.current?.scrollTo(0, scrollRef.current.scrollHeight);
   }, [messages]);
 
-  // After rendering an entry message, auto-advance to the first MC question
+  // After the entry message is displayed, automatically advance
   useEffect(() => {
-    if (currentNode?.type === 'message' && currentNode.content.options?.length === 0) {
-      if (currentNode.id === 'entry') {
+    if (currentNode?.id === 'entry') {
+      const timer = setTimeout(() => {
         handleOptionClick('');
-      }
+      }, 1500);
+      return () => clearTimeout(timer);
     }
   }, [currentNode]);
 

--- a/client/src/components/DashboardView.tsx
+++ b/client/src/components/DashboardView.tsx
@@ -4,9 +4,10 @@ import { colors } from "../theme";
 interface Props {
   onStartSurvey: () => void;
   onViewResults: (surveyId?: string) => void;
+  onGoToExisting: () => void;
 }
 
-export default function DashboardView({ onStartSurvey, onViewResults }: Props) {
+export default function DashboardView({ onStartSurvey, onViewResults, onGoToExisting }: Props) {
   return (
     <div>
       <div className="dashboard-header">
@@ -33,6 +34,9 @@ export default function DashboardView({ onStartSurvey, onViewResults }: Props) {
       <h2 className="dashboard-hero">Dig Your Burrow!</h2>
       <div className="action-card" onClick={onStartSurvey}>
         Dig New Burrow
+      </div>
+      <div className="action-card" onClick={onGoToExisting}>
+        Existing Surveys
       </div>
       <div className="action-card" onClick={() => onViewResults()}>
         The Den (Survey Results)

--- a/client/src/components/ExistingSurveysView.tsx
+++ b/client/src/components/ExistingSurveysView.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { API_URL } from '../config';
+
+interface Props {
+  onSelectSurvey: (id: string) => void;
+}
+
+interface SurveySummary {
+  id: string;
+  objective: string;
+  createdAt: string;
+}
+
+export default function ExistingSurveysView({ onSelectSurvey }: Props) {
+  const [surveys, setSurveys] = useState<SurveySummary[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/survey`)
+      .then(res => res.json())
+      .then(data => setSurveys(data.surveys || []))
+      .catch(err => console.error('Failed to fetch surveys', err));
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2 className="dashboard-hero" style={{ marginBottom: '24px' }}>Existing Surveys</h2>
+      {surveys.map(s => (
+        <div
+          key={s.id}
+          className="action-card"
+          onClick={() => onSelectSurvey(s.id)}
+          role="button"
+          tabIndex={0}
+          onKeyPress={(e) => e.key === 'Enter' && onSelectSurvey(s.id)}
+          style={{ marginBottom: '1rem', cursor: 'pointer' }}
+        >
+          <h3 style={{ margin: '0 0 0.5rem 0' }}>{s.objective}</h3>
+          <p style={{ margin: 0, fontSize: '0.9em' }}>
+            Created: {new Date(s.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/WizardStepObjective.tsx
+++ b/client/src/components/WizardStepObjective.tsx
@@ -16,6 +16,12 @@ export default function WizardStepObjective({ initialObjective = "", loading, er
   const [title, setTitle] = useState('');
   const [touched, setTouched] = useState(false);
   const [showMethodology, setShowMethodology] = useState(false);
+  const classes = [
+    '1st Period: Freshman English',
+    '2nd Period: Senior English',
+    '3rd Period: AP English',
+    '4th Period: Advanced Composition'
+  ];
   // For accessibility let user submit with Enter+Ctrl (multiline otherwise)
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -52,6 +58,14 @@ export default function WizardStepObjective({ initialObjective = "", loading, er
             onChange={(e) => setTitle(e.target.value)}
             disabled={loading}
           />
+        </div>
+        <div className="field-group">
+          <label htmlFor="class" className="field-label">Class</label>
+          <select id="class" className="field-input" disabled={loading}>
+            {classes.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
         </div>
       </div>
       <label htmlFor="objective" className="field-label">

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ export default [
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require('@typescript-eslint/parser')
     },
     plugins: {
       '@typescript-eslint': require('@typescript-eslint/eslint-plugin')

--- a/server/routes/survey.ts
+++ b/server/routes/survey.ts
@@ -33,6 +33,21 @@ router.post('/', async (req, res) => {
   }
 });
 
+// Fetch all surveys ordered by creation date (new endpoint)
+router.get('/', async (_req, res) => {
+  try {
+    const surveys = await prisma.survey.findMany({
+      orderBy: {
+        createdAt: 'desc'
+      }
+    });
+    res.json({ surveys });
+  } catch (error) {
+    console.error('Error fetching surveys:', error);
+    res.status(500).json({ error: 'Failed to fetch surveys' });
+  }
+});
+
 router.patch('/:id/question/:qid', async (req, res) => {
   const { qid } = req.params;
   const { text } = req.body;


### PR DESCRIPTION
## Summary
- add endpoint to list surveys
- add existing surveys dashboard view
- auto-advance chat demo entry node
- track survey completion and enable Seed button
- add class dropdown in wizard
- fix ESLint parser path

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to fetch Prisma binary due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851fe227a888324955cda27b44e64fd