### PR TITLE
Implement graph view for existing surveys

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,7 +6,6 @@ import StudentPlaceholder from "./components/StudentPlaceholder";
 import ResultsView from "./components/ResultsView";
 import DenHome from "./components/DenHome";
 import ExistingSurveysView from "./components/ExistingSurveysView";
-import ChatOverlay from "./components/ChatOverlay";
 
 import Login from "./Login";
 import "./index.css";
@@ -40,15 +39,22 @@ export default function App() {
   const { token, role } = useAuthInfo();
   const [page, setPage] = useState("dashboard");
   const [activeSurveyIdForResults, setActiveSurveyIdForResults] = useState<string | null>(null);
-  const [demoSurveyId, setDemoSurveyId] = useState<string | null>(null);
+  // hold the id of a survey being edited in the builder
+  const [surveyIdToEdit, setSurveyIdToEdit] = useState<string | null>(null);
 
   const handleNavigate = (p: string, surveyId?: string) => {
-    if (p === "results") {
+    if (p === 'results') {
       setActiveSurveyIdForResults(surveyId || null);
-      setPage(p);
-    } else {
-      setPage(p);
     }
+    setPage(p);
+    if (p !== 'builder') {
+      setSurveyIdToEdit(null);
+    }
+  };
+
+  const handleLoadSurveyInBuilder = (id: string) => {
+    setSurveyIdToEdit(id);
+    setPage('builder');
   };
 
   const handleLogout = () => {
@@ -74,9 +80,6 @@ export default function App() {
     setActiveSurveyIdForResults(surveyId);
   };
 
-  const handleSelectExistingSurvey = (id: string) => {
-    setDemoSurveyId(id);
-  };
 
   return (
     <div className="dashboard-layout">
@@ -92,17 +95,15 @@ export default function App() {
             <DenHome onSelectSurvey={handleSelectSurveyInDen} />
           )
         ) : page === 'builder' ? (
-          <Wizard />
+          <Wizard surveyIdToLoad={surveyIdToEdit} />
         ) : page === 'existing' ? (
-          <>
-            <ExistingSurveysView onSelectSurvey={handleSelectExistingSurvey} />
-            {demoSurveyId && (
-              <ChatOverlay surveyId={demoSurveyId} onClose={() => setDemoSurveyId(null)} />
-            )}
-          </>
+          <ExistingSurveysView onSelectSurvey={handleLoadSurveyInBuilder} />
         ) : (
           <DashboardView
-            onStartSurvey={() => setPage('builder')}
+            onStartSurvey={() => {
+              setSurveyIdToEdit(null);
+              setPage('builder');
+            }}
             onViewResults={(surveyId?: string) => handleNavigate('results', surveyId)}
             onGoToExisting={() => setPage('existing')}
           />

--- a/client/src/components/Wizard.tsx
+++ b/client/src/components/Wizard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import WizardStepObjective from "./WizardStepObjective";
 import BranchingGraphView, { BranchNode, BranchEdge } from "./BranchingGraphView";
 import { API_URL } from "../config";
@@ -25,7 +25,11 @@ export interface GeneratedQuestion {
   rubric: RubricItem[];
 }
 
-export default function Wizard() {
+interface WizardProps {
+  surveyIdToLoad?: string | null;
+}
+
+export default function Wizard({ surveyIdToLoad }: WizardProps) {
   const [step, setStep] = useState<Step>(Step.Objective);
   const [objective, setObjective] = useState<string>("");
   const [surveyId, setSurveyId] = useState<string | null>(null);
@@ -33,6 +37,28 @@ export default function Wizard() {
   const [edges, setEdges] = useState<BranchEdge[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Load an existing survey if an id is provided
+  useEffect(() => {
+    if (surveyIdToLoad) {
+      setLoading(true);
+      setError(null);
+      fetch(`${API_URL}/api/survey/branching/${surveyIdToLoad}`)
+        .then((res) => {
+          if (!res.ok) throw new Error('Failed to load survey data.');
+          return res.json();
+        })
+        .then((data) => {
+          setObjective(data.objective);
+          setSurveyId(data.surveyId);
+          setNodes(data.nodes);
+          setEdges(data.edges);
+          setStep(Step.Graph);
+        })
+        .catch((err: any) => setError(err.message))
+        .finally(() => setLoading(false));
+    }
+  }, [surveyIdToLoad]);
 
   const handleBack = () => setStep((prev) => (prev === Step.Graph ? Step.Objective : prev));
 
@@ -181,7 +207,10 @@ export default function Wizard() {
         Burrow Builder
       </h1>
       <Stepper />
-      {step === Step.Objective && (
+      {loading && step === Step.Objective && (
+        <div>Loading survey...</div>
+      )}
+      {step === Step.Objective && !loading && (
         <WizardStepObjective
           initialObjective={objective}
           loading={loading}

--- a/server/routes/branchingSurvey.ts
+++ b/server/routes/branchingSurvey.ts
@@ -25,6 +25,40 @@ router.put('/:id', async (req, res) => {
   res.json({ message: 'updated' });
 });
 
+// New route to fetch a survey along with its nodes and edges
+router.get('/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const survey = await prisma.survey.findUnique({
+      where: { id },
+      include: {
+        nodes: true,
+        edges: true
+      }
+    });
+
+    if (!survey) {
+      return res.status(404).json({ error: 'Survey not found' });
+    }
+
+    const normalizedEdges = survey.edges.map((e) => ({
+      sourceNodeId: e.sourceNodeId,
+      targetNodeId: e.targetNodeId,
+      conditionValue: e.conditionValue || undefined
+    }));
+
+    res.json({
+      surveyId: survey.id,
+      objective: survey.objective,
+      nodes: survey.nodes,
+      edges: normalizedEdges
+    });
+  } catch (error) {
+    console.error(`Error fetching branching survey ${id}:`, error);
+    res.status(500).json({ error: 'Failed to fetch survey graph' });
+  }
+});
+
 router.get('/:id/start', async (req, res) => {
   const node = await getEntryNode(req.params.id);
   if (!node) return res.status(404).json({ error: 'entry node not found' });


### PR DESCRIPTION
## Summary
- expose GET `/api/survey/branching/:id` to fetch graph data
- load existing branching surveys into the wizard builder
- tweak wizard to fetch survey data and skip to graph view

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to fetch Prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68522e5a44988324b087b47eb1c4d9a8