### PR TITLE
Add branching survey seeding and results APIs

### DIFF
--- a/client/src/components/BranchingGraphView.tsx
+++ b/client/src/components/BranchingGraphView.tsx
@@ -14,6 +14,7 @@ import 'reactflow/dist/style.css';
 import { colors } from '../theme';
 import MethodologyModal from './MethodologyModal';
 import ChatOverlay from './ChatOverlay';
+import { API_URL } from '../config';
 
 // Node data passed into the custom node component
 interface NodeData {
@@ -118,6 +119,20 @@ export default function BranchingGraphView({
   const handleShowRationale = (rationale: string) => {
     setRationaleContent(rationale);
     setShowRationaleModal(true);
+  };
+
+  const handleSeedAndAnalyze = async () => {
+    try {
+      const res = await fetch(
+        `${API_URL}/api/survey/branching/${surveyId}/seed-and-analyze`,
+        { method: 'POST' }
+      );
+      if (!res.ok) throw new Error('Failed');
+      alert('Survey seeded and analyzed. Check "The Den" for results.');
+    } catch (err) {
+      console.error(err);
+      alert('Error seeding survey');
+    }
   };
 
   // Register custom node type
@@ -290,6 +305,7 @@ export default function BranchingGraphView({
         </button>
         <button
           className="login-button"
+          onClick={handleSeedAndAnalyze}
           style={{
             marginTop: '1rem',
             marginLeft: '1rem'

--- a/client/src/components/BranchingRawData.tsx
+++ b/client/src/components/BranchingRawData.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { API_URL } from '../config';
+
+interface RawResponse {
+  answer: string;
+}
+interface QuestionData {
+  nodeId: string;
+  text: string;
+  rawResponses: RawResponse[];
+}
+
+export default function BranchingRawData({ surveyId }: { surveyId: string }) {
+  const [questions, setQuestions] = useState<QuestionData[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/survey/branching/${surveyId}/results`)
+      .then((res) => res.json())
+      .then((d) => setQuestions(d.questions || []))
+      .catch(() => setQuestions([]));
+  }, [surveyId]);
+
+  if (!questions.length) return <div>No results data.</div>;
+
+  return (
+    <div>
+      {questions.map((q) => (
+        <div key={q.nodeId} style={{ marginBottom: '1rem' }}>
+          <strong>{q.text}</strong>
+          <ul>
+            {q.rawResponses.map((r, i) => (
+              <li key={i}>{r.answer}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/BranchingResultsCharts.tsx
+++ b/client/src/components/BranchingResultsCharts.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { API_URL } from '../config';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface QuestionResult {
+  nodeId: string;
+  text: string;
+  aggregation: Record<string, number>;
+}
+
+export default function BranchingResultsCharts({ surveyId }: { surveyId: string }) {
+  const [data, setData] = useState<QuestionResult[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/survey/branching/${surveyId}/results`)
+      .then((res) => res.json())
+      .then((d) => setData(d.questions || []))
+      .catch(() => setData([]));
+  }, [surveyId]);
+
+  if (!data.length) return <div>No results data.</div>;
+
+  return (
+    <div>
+      {data.map((q) => {
+        const labels = Object.keys(q.aggregation);
+        const chartData = {
+          labels,
+          datasets: [
+            {
+              label: 'Responses',
+              data: labels.map((l) => q.aggregation[l] || 0),
+              backgroundColor: 'rgba(75,192,192,0.6)'
+            }
+          ]
+        };
+        return (
+          <div key={q.nodeId} style={{ marginBottom: '2rem' }}>
+            <h3>{q.text}</h3>
+            <Bar data={chartData} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/ResultsView.tsx
+++ b/client/src/components/ResultsView.tsx
@@ -3,6 +3,8 @@ import { API_URL } from '../config';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import ResultsCharts from './ResultsCharts';
+import BranchingResultsCharts from './BranchingResultsCharts';
+import BranchingRawData from './BranchingRawData';
 
 interface SurveyAnalysis {
   analysis: string;
@@ -20,7 +22,8 @@ export default function ResultsView({ surveyId: propSurveyId, onGoBackToList }: 
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [currentSurveyId, setCurrentSurveyId] = useState<string | null>(propSurveyId);
-  const [mode, setMode] = useState<'markdown' | 'charts'>('markdown');
+  const [view, setView] = useState<'analysis' | 'charts' | 'data'>('analysis');
+  const [isBranching, setIsBranching] = useState<boolean>(false);
 
   useEffect(() => {
     async function fetchActiveSurvey() {
@@ -52,6 +55,14 @@ export default function ResultsView({ surveyId: propSurveyId, onGoBackToList }: 
       if (error) setLoading(false);
       return;
     }
+
+    // determine if survey has branching nodes
+    fetch(`${API_URL}/api/survey/branching/${currentSurveyId}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        setIsBranching(!!data && Array.isArray(data.nodes) && data.nodes.length > 0);
+      })
+      .catch(() => setIsBranching(false));
 
     setLoading(true);
     setError(null);
@@ -100,25 +111,44 @@ export default function ResultsView({ surveyId: propSurveyId, onGoBackToList }: 
       <div style={{ marginBottom: '1rem' }}>
         <button
           className="login-button"
-          onClick={() => setMode('markdown')}
-          disabled={mode === 'markdown'}
+          onClick={() => setView('analysis')}
+          disabled={view === 'analysis'}
         >
           Report
         </button>
         <button
           className="login-button"
-          onClick={() => setMode('charts')}
-          disabled={mode === 'charts'}
+          onClick={() => setView('charts')}
+          disabled={view === 'charts'}
           style={{ marginLeft: '0.5rem' }}
         >
           Charts
         </button>
+        {isBranching && (
+          <button
+            className="login-button"
+            onClick={() => setView('data')}
+            disabled={view === 'data'}
+            style={{ marginLeft: '0.5rem' }}
+          >
+            Raw Data
+          </button>
+        )}
       </div>
       <div style={{ color: '#333', lineHeight: 1.6 }}>
-        {mode === 'markdown' ? (
+        {view === 'analysis' && (
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{analysis}</ReactMarkdown>
-        ) : (
-          currentSurveyId && <ResultsCharts surveyId={currentSurveyId} />
+        )}
+        {view === 'charts' && (
+          currentSurveyId &&
+          (isBranching ? (
+            <BranchingResultsCharts surveyId={currentSurveyId} />
+          ) : (
+            <ResultsCharts surveyId={currentSurveyId} />
+          ))
+        )}
+        {view === 'data' && currentSurveyId && (
+          <BranchingRawData surveyId={currentSurveyId} />
         )}
       </div>
     </div>

--- a/server/db/branchingResponseSeed.ts
+++ b/server/db/branchingResponseSeed.ts
@@ -1,28 +1,7 @@
-import { PrismaClient, Node } from '@prisma/client';
-import { getEntryNode, getNextNode } from '../services/branchingSurveyService';
+import { PrismaClient } from '@prisma/client';
+import { seedBranchingSurveyResponses } from '../services/branchingSurveyService';
 
 const prisma = new PrismaClient();
-
-async function simulateStudent(surveyId: string, entryNode: Node) {
-  let currentNode: Node | null = entryNode;
-  const responses: { nodeId: string; answer: string }[] = [];
-
-  while (currentNode) {
-    if (currentNode.type === 'question-multiple-choice') {
-      const options = (currentNode.content as any)?.options;
-      if (!options || options.length === 0) {
-        break; // Stop if a question has no options
-      }
-      const answer = options[Math.floor(Math.random() * options.length)];
-      responses.push({ nodeId: currentNode.id, answer });
-      currentNode = await getNextNode(surveyId, currentNode.id, answer);
-    } else {
-      currentNode = await getNextNode(surveyId, currentNode.id, '');
-    }
-  }
-
-  return responses;
-}
 
 async function main() {
   console.log('Starting to seed branching survey responses...');
@@ -45,28 +24,8 @@ async function main() {
 
   console.log(`Seeding responses for survey: "${survey.objective}" (ID: ${survey.id})`);
 
-  const entryNode = await getEntryNode(survey.id);
-  if (!entryNode) {
-    console.error('Could not find an entry node for the survey.');
-    return;
-  }
-
-  const numberOfStudents = 25;
-  let allResponses: { nodeId: string; answer: string }[] = [];
-
-  for (let i = 0; i < numberOfStudents; i++) {
-    const studentResponses = await simulateStudent(survey.id, entryNode);
-    allResponses.push(...studentResponses);
-  }
-
-  if (allResponses.length > 0) {
-    await prisma.response.createMany({
-      data: allResponses
-    });
-    console.log(`Successfully seeded ${allResponses.length} responses for ${numberOfStudents} students.`);
-  } else {
-    console.log('No responses were generated to seed.');
-  }
+  const created = await seedBranchingSurveyResponses(survey.id, 25);
+  console.log(`Seeded ${created} responses for survey ${survey.id}`);
 }
 
 main()

--- a/server/routes/branchingSurvey.ts
+++ b/server/routes/branchingSurvey.ts
@@ -3,10 +3,13 @@ import {
   createBranchingSurvey,
   updateBranchingSurvey,
   getEntryNode,
-  getNextNode
+  getNextNode,
+  seedBranchingSurveyResponses,
+  getBranchingSurveyResults
 } from '../services/branchingSurveyService';
 import { generateBranchingSurvey } from '../services/claudeService';
 import { prisma } from '../prisma/client';
+import { analyzeBranchingSurvey } from '../services/analysisService';
 
 const router = Router();
 
@@ -71,6 +74,28 @@ router.post('/:id/next', async (req, res) => {
   const node = await getNextNode(req.params.id, currentNodeId, answer);
   if (!node) return res.status(404).json({ error: 'next node not found' });
   res.json({ node });
+});
+
+router.post('/:id/seed-and-analyze', async (req, res) => {
+  const { id } = req.params;
+  try {
+    await seedBranchingSurveyResponses(id, 25);
+    const analysis = await analyzeBranchingSurvey(id);
+    res.json({ analysis });
+  } catch (error) {
+    console.error('Error seeding and analyzing branching survey:', error);
+    res.status(500).json({ error: 'Failed to seed and analyze survey' });
+  }
+});
+
+router.get('/:id/results', async (req, res) => {
+  try {
+    const results = await getBranchingSurveyResults(req.params.id);
+    res.json(results);
+  } catch (error) {
+    console.error('Error fetching branching survey results:', error);
+    res.status(500).json({ error: 'Failed to fetch results' });
+  }
 });
 
 export default router;

--- a/server/services/branchingSurveyService.ts
+++ b/server/services/branchingSurveyService.ts
@@ -81,3 +81,91 @@ export async function getNextNode(
   if (!match) return null;
   return prisma.node.findFirst({ where: { id: match.targetNodeId, surveyId } });
 }
+
+/** Simulate a single student's path through the survey */
+async function simulateStudent(
+  surveyId: string,
+  entryNode: Node
+): Promise<Array<{ nodeId: string; answer: string }>> {
+  let currentNode: Node | null = entryNode;
+  const responses: { nodeId: string; answer: string }[] = [];
+
+  while (currentNode) {
+    if (currentNode.type === 'question-multiple-choice') {
+      const options = (currentNode.content as any)?.options as string[] | undefined;
+      if (!options || options.length === 0) break;
+      const answer = options[Math.floor(Math.random() * options.length)];
+      responses.push({ nodeId: currentNode.id, answer });
+      currentNode = await getNextNode(surveyId, currentNode.id, answer);
+    } else {
+      currentNode = await getNextNode(surveyId, currentNode.id, '');
+    }
+  }
+
+  return responses;
+}
+
+/**
+ * Seed branching survey responses for a demo by simulating multiple students.
+ */
+export async function seedBranchingSurveyResponses(
+  surveyId: string,
+  count = 25
+): Promise<number> {
+  const entry = await getEntryNode(surveyId);
+  if (!entry) throw new Error('Entry node not found');
+
+  let all: { nodeId: string; answer: string }[] = [];
+  for (let i = 0; i < count; i++) {
+    const student = await simulateStudent(surveyId, entry);
+    all.push(...student);
+  }
+
+  if (all.length) {
+    await prisma.response.createMany({ data: all });
+  }
+  return all.length;
+}
+
+export interface BranchingSurveyResults {
+  questions: Array<{
+    nodeId: string;
+    text: string;
+    options: string[];
+    aggregation: Record<string, number>;
+    rawResponses: Array<{ answer: string }>;
+  }>;
+}
+
+/**
+ * Retrieve aggregated and raw results for a branching survey.
+ */
+export async function getBranchingSurveyResults(
+  surveyId: string
+): Promise<BranchingSurveyResults> {
+  const nodes = await prisma.node.findMany({
+    where: { surveyId, type: 'question-multiple-choice' },
+    include: { responses: true }
+  });
+
+  const questions = nodes.map((n) => {
+    const text = (n.content as any)?.text ?? '';
+    const options: string[] = (n.content as any)?.options ?? [];
+    const aggregation: Record<string, number> = {};
+    options.forEach((o) => {
+      aggregation[o] = 0;
+    });
+    n.responses.forEach((r) => {
+      aggregation[r.answer] = (aggregation[r.answer] || 0) + 1;
+    });
+    return {
+      nodeId: n.id,
+      text,
+      options,
+      aggregation,
+      rawResponses: n.responses.map((r) => ({ answer: r.answer }))
+    };
+  });
+
+  return { questions };
+}


### PR DESCRIPTION
## Summary
- move branching survey seeding logic into service
- allow seeding via API and fetch aggregated results
- show branching survey charts and raw data in results view
- enable seeding from graph view

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to fetch prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6852d160a73c832480e3344229ca05db