### PR TITLE
Align config with server workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,17 +5,17 @@
     "server",
     "client"
   ],
-"scripts": {
-  "build": "npx prisma generate --schema=./api/prisma/schema.prisma && npx prisma db push --schema=./api/prisma/schema.prisma && npm run build --prefix client",
-  "dev": "concurrently -k --names \"API,CLIENT\" \"npm --prefix api run dev\" \"npm --prefix client run dev\"",
-  "mailhog": "bash ./scripts/mailhog.sh",
-  "tunnel": "bash ./scripts/tunnel.sh",
-  "demo:seed": "npm --prefix api run demo:seed",
-  "db:seed": "npm --prefix api run db:seed",
-  "db:seed:branching": "ts-node api/db/branchingResponseSeed.ts",
-  "lint": "eslint \"**/*.{ts,tsx}\"",
-  "test": "vitest"
-},
+  "scripts": {
+    "build": "npx prisma generate --schema=./server/prisma/schema.prisma && npx prisma db push --schema=./server/prisma/schema.prisma && npm run build --prefix client",
+    "dev": "concurrently -k --names \"SERVER,CLIENT\" \"npm --prefix server run dev\" \"npm --prefix client run dev\"",
+    "mailhog": "bash ./scripts/mailhog.sh",
+    "tunnel": "bash ./scripts/tunnel.sh",
+    "demo:seed": "npm --prefix server run demo:seed",
+    "db:seed": "npm --prefix server run db:seed",
+    "db:seed:branching": "ts-node server/db/branchingResponseSeed.ts",
+    "lint": "eslint \"**/*.{ts,tsx}\"",
+    "test": "vitest"
+  },
   "devDependencies": {
     "concurrently": "^8.2.0",
     "eslint": "^8.52.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
-  - "api"
+  - "server"
   - "client"

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/(.*)",
-      "destination": "/api/index.ts"
+      "destination": "/server/index.ts"
     }
   ]
 }

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -2,7 +2,7 @@ const { execSync } = require('child_process');
 // Apply Prisma schema before tests (run in each worker)
 try {
   console.log('Applying Prisma schema to database for tests...');
-  execSync('npx prisma db push --schema=api/prisma/schema.prisma --skip-generate', { stdio: 'inherit' });
+  execSync('npx prisma db push --schema=server/prisma/schema.prisma --skip-generate', { stdio: 'inherit' });
 } catch (error) {
   console.error('Failed to apply Prisma schema before tests:', error);
   process.exit(1);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,9 +1,0 @@
-import { execSync } from 'child_process';
-// Apply Prisma schema before tests (run in each worker)
-try {
-  console.log('Applying Prisma schema to database for tests...');
-  execSync('npx prisma db push --schema=server/prisma/schema.prisma --skip-generate', { stdio: 'inherit' });
-} catch (error) {
-  console.error('Failed to apply Prisma schema before tests:', error);
-  process.exit(1);
-}


### PR DESCRIPTION
## Summary
- point root scripts and workspace to `server`
- update Vercel rewrite to `/server/index.ts`
- fix vitest Prisma path and remove unused setup file

## Testing
- `npm run lint`
- `npm test` *(fails: unable to download prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_687583832c888324806f85933b0c8c94