### PR TITLE
Expose server app via api entry

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../server/index';

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,13 @@
 {
+  "functions": {
+    "api/index.ts": {
+      "includedFiles": "docs/**"
+    }
+  },
   "rewrites": [
     {
       "source": "/api/(.*)",
-      "destination": "/server/index.ts"
+      "destination": "/api/index.ts"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.ts": {
-      "includedFiles": "docs/**"
+      "includeFiles": "docs/**"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- add api wrapper to export Express app
- include docs folder in Vercel serverless function
- update rewrite to `/api/index.ts`

## Testing
- `npm run lint`
- `npm test` *(fails: failed to fetch Prisma engine checksums)*

------
https://chatgpt.com/codex/tasks/task_e_68758942869083248d4d8b5838ca3c76